### PR TITLE
Support for a nicer structure for ID maps

### DIFF
--- a/docs/source/identmap.rst
+++ b/docs/source/identmap.rst
@@ -2,8 +2,35 @@ IdentMap
 ********
 An IdentMap is used to map multiple (U)ID's of one client to one client.
 This can be useful, if a user creates multiple identities and you want to summarize all actions from all identities.
+To pass an IdentMap to TeamspeakStats, create your IdentMap as shown above and pass it to the cli::
+
+  tsstats --idmap <path to idmap.json>
 
 TeamspeakStats' IdentMap-file is saved in json-format::
+
+  [
+    {
+      "primary_id": "1",
+      "alternate_ids": ["2", "3", "4"]
+    }
+  ]
+
+If you would pass this IdentMap to TeamspeakStats and your log would contain entries for clients with id's 1, 2, 3 and 4,
+your output will just show data for one client (1).
+
+The format is flexible enough to support other arbitrary data to assist you in maintaining your IdentMap::
+
+  [
+    {
+      "name": "Friend 1",
+      "primary_id": "1",
+      "alternate_ids": ["2", "3", "4"]
+    }
+  ]
+
+The parser will ignore all nodes other than the "primary_id" and "alternate_ids" nodes, allowing you to use them for whatever you want.
+
+The original IdentMap format is still supported:
 
   {
     '2': '1',
@@ -11,10 +38,4 @@ TeamspeakStats' IdentMap-file is saved in json-format::
     '4': '1'
   }
 
-
-If you would pass this IdentMap to TeamspeakStats and your log would contain entries for clients with id's 1, 2, 3 and 4,
-your output will just show data for one client (1).
-
-To pass an IdentMap to TeamspeakStats, create your IdentMap as shown above and pass it to the cli::
-
-  tsstats --idmap <path to idmap.json>
+While it is less expressive, it is also less verbose.

--- a/tsstats/__main__.py
+++ b/tsstats/__main__.py
@@ -9,6 +9,7 @@ from tsstats import config
 from tsstats.exceptions import InvalidConfiguration
 from tsstats.log import parse_logs
 from tsstats.template import render_servers
+from tsstats.utils import transform_pretty_identmap
 
 logger = logging.getLogger('tsstats')
 
@@ -77,6 +78,8 @@ def main(configuration):
         identmap = json.load(open(idmap))
     else:
         identmap = None
+    if isinstance(identmap, list):
+        identmap = transform_pretty_identmap(identmap)
 
     log = configuration.get('General', 'log')
     if not log:

--- a/tsstats/tests/test_ident_map.py
+++ b/tsstats/tests/test_ident_map.py
@@ -43,7 +43,7 @@ def test_ident_map(identmap_clients):
         (('4', '2'), ('9', '8'), ('14', '8'))
     )
 ])
-def test_flip_pretty_identmap(test_input, expected):
+def test_transform_pretty_identmap(test_input, expected):
     transformed_identmap = transform_pretty_identmap(test_input)
     for alternate, primary in expected:
         assert transformed_identmap[alternate] == primary

--- a/tsstats/tests/test_ident_map.py
+++ b/tsstats/tests/test_ident_map.py
@@ -27,14 +27,6 @@ def test_ident_map(identmap_clients):
     assert clients['UID5'] == uidcl
 
 
-@pytest.fixture(scope="module")
-def pretty_identmap():
-    return [
-        {'primary_id': '1', 'alternate_ids': ['3', '6']},
-        {'primary_id': '4', 'alternate_ids': ['9', '42']}
-    ]
-
-
 @pytest.mark.parametrize('test_input,expected', [
     (
         [

--- a/tsstats/tests/test_ident_map.py
+++ b/tsstats/tests/test_ident_map.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tsstats.client import Client, Clients
+from tsstats.utils import transform_pretty_identmap
 
 
 @pytest.fixture(scope='module')
@@ -24,3 +25,33 @@ def test_ident_map(identmap_clients):
     assert clients['5'] == cl
     assert clients['UID1'] == uidcl
     assert clients['UID5'] == uidcl
+
+
+@pytest.fixture(scope="module")
+def pretty_identmap():
+    return [
+        {'primary_id': '1', 'alternate_ids': ['3', '6']},
+        {'primary_id': '4', 'alternate_ids': ['9', '42']}
+    ]
+
+
+@pytest.mark.parametrize('test_input,expected', [
+    (
+        [
+            {'primary_id': '1', 'alternate_ids': ['3', '6']},
+            {'primary_id': '4', 'alternate_ids': ['9', '42', '23']}
+        ],
+        (('3', '1'), ('6', '1'), ('9', '4'), ('42', '4'), ('23', '4'))
+    ),
+    (
+        [
+            {'name': 'Friend 1', 'primary_id': '2', 'alternate_ids': ['4']},
+            {'name': 'Friend 3', 'primary_id': '8', 'alternate_ids': ['9', '14']}
+        ],
+        (('4', '2'), ('9', '8'), ('14', '8'))
+    )
+])
+def test_flip_pretty_identmap(test_input, expected):
+    transformed_identmap = transform_pretty_identmap(test_input)
+    for alternate, primary in expected:
+        assert transformed_identmap[alternate] == primary

--- a/tsstats/utils.py
+++ b/tsstats/utils.py
@@ -78,3 +78,22 @@ def tz_aware_datime(datetime, timezone=UTC()):
     :type timezone: datetime.timezone
     '''
     return datetime.replace(tzinfo=timezone)
+
+
+def transform_pretty_identmap(pretty_identmap):
+    '''
+    Transforms a list of client ID mappings from a more descriptive format
+    to the traditional format of alternative IDs to actual ID.
+
+    :param pretty_identmap: ID mapping in "nice" form
+    :type pretty_identmap: list
+
+    :return: ID mapping in simple key/value pairs
+    :rtype: dict
+    '''
+
+    final_identmap = {}
+    for mapping in pretty_identmap:
+        for alt_id in mapping['alternate_ids']:
+            final_identmap[alt_id] = mapping['primary_id']
+    return final_identmap


### PR DESCRIPTION
This is a proof of concept for #11 that allows use of a JSON ID map that
looks like this:

    [
      {
        "primary_id": "1",
        "alternate_ids": ["2", "5", "11"]
      },
      {
        "primary_id": "4",
        "alternate_ids": ["17", "82"]
      }
    ]

Because of how the code is structured, there's nothing stopping you from
using an ID map that looks like this:

    [
      {
        "name": "Friend 1",
        "primary_id": "1",
        "alternate_ids": ["2", "5", "11"]
      },
      {
        "name": "Friend 2",
        "primary_id": "4",
        "alternate_ids": ["17", "82"]
      }
    ]

If you're happy with this implementation, I'll start updating the docs,
and add some tests too.