### PR TITLE
Improve presentation at mobile

### DIFF
--- a/tsstats/templates/index.jinja2
+++ b/tsstats/templates/index.jinja2
@@ -6,9 +6,17 @@
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/hint.css/2.4.1/hint.min.css" integrity="sha256-7KczUWqIa/6KaIKtNfG18eilVQR4vJ4S9SSiDAplUwc=" crossorigin="anonymous">
   <meta name="referrer" content="no-referrer">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style type="text/css">
     body {
       padding-top: 50px;
+    }
+    @media screen and (max-width: 767px) {
+      .hint--medium--xs:after {
+        white-space: normal;
+        line-height: 1.4em;
+        word-wrap: break-word;
+      }
     }
   </style>
 </head>

--- a/tsstats/templates/stats.jinja2
+++ b/tsstats/templates/stats.jinja2
@@ -13,7 +13,7 @@
     {% for client, value in clients %}
     {% set id = [headline_id, client.nick|striptags]|join('.') %}
     <li id="{{ id }}" onclick="window.location = '#{{ id }}'" class="list-group-item{{ ' list-group-item-success' if client.connected else loop.cycle('" style="background-color: #eee;', '') }}">
-      <span class="hint--right" data-hint="{{ client.nick_history|join(', ') }}">{{ client.nick }}{{ " (" + client.identifier + ")" if debug }}</span>
+      <span class="hint--right hint--medium--xs" data-hint="{{ client.nick_history|join(', ') }}">{{ client.nick }}{{ " (" + client.identifier + ")" if debug }}</span>
       <span class="badge"><div{% if not client.connected and headline == 'Onlinetime' %} class="hint--left" data-hint="{{ client.last_seen|frmttime }}"{% endif %}>{{ value }}</div></span>
     </li>
     {% endfor %}


### PR DESCRIPTION
- Add custom hint--medium--xs style, to make the tooltips wrap neatly
- Add meta viewport tag

This doesn't solve the issue of the list of servers in the navbar overlapping
content when there's too many of them, but I'm not sure how to nicely solve
that problem without bringing in the bootstrap collapse JS component.