### PR TITLE
Add ability to pass a directory for --log option

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -21,7 +21,8 @@ To start, you can just use cli-arguments to control the behaviour of TeamspeakSt
     -c CONFIG, --config CONFIG
                           path to config
     --idmap IDMAP         path to id_map
-    -l LOG, --log LOG     path to your logfile(s)
+    -l LOG, --log LOG     path to your logfile(s). pass a directory to use all
+                          logfiles inside it
     -o OUTPUT, --output OUTPUT
                           path to the output-file
     -d, --debug           debug mode

--- a/tsstats/__main__.py
+++ b/tsstats/__main__.py
@@ -3,7 +3,7 @@
 import argparse
 import json
 import logging
-from os.path import abspath, exists
+from os.path import abspath, exists, isdir, join as pathjoin
 
 from tsstats import config
 from tsstats.exceptions import InvalidConfiguration
@@ -30,7 +30,7 @@ def cli():
     )
     parser.add_argument(
         '-l', '--log',
-        type=str, help='path to your logfile(s)'
+        type=str, help='path to your logfile(s). pass a directory to use all logfiles inside it'
     )
     parser.add_argument(
         '-o', '--output',
@@ -98,6 +98,8 @@ def main(configuration):
     log = configuration.get('General', 'log')
     if not log:
         raise InvalidConfiguration('log or output missing')
+    if isdir(log):
+        log = pathjoin(log, '*.log')
 
     servers = parse_logs(
         log, ident_map=identmap,


### PR DESCRIPTION
If you pass a directory, it will now tack a '*.log' glob on the end of
the path to automatically use all log files inside this directory.