### PR TITLE
Switch to Pendulum for datetime and timestamp handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Jinja2>=2.8
+pendulum

--- a/tsstats/__main__.py
+++ b/tsstats/__main__.py
@@ -64,6 +64,11 @@ def cli():
         '-otth', '--onlinetimethreshold',
         type=int, help='threshold for displaying onlinetime (in seconds)'
     )
+    parser.add_argument(
+        '-lsa', '--lastseenabsolute',
+        help='render last seen timestamp absolute (instead of relative)',
+        action='store_false', dest='lastseenrelative'
+    )
     options = parser.parse_args()
     if 'config' in options:
         configuration = config.load(options.config)
@@ -115,7 +120,11 @@ def main(configuration):
         template=configuration.get('General', 'template'),
         datetime_fmt=configuration.get('General', 'datetimeformat'),
         onlinetime_threshold=int(configuration.get(
-            'General', 'onlinetimethreshold'))
+            'General', 'onlinetimethreshold'
+        )),
+        lastseen_relative=configuration.getboolean(
+            'General', 'lastseenrelative'
+        )
     )
     logger.info('Finished after %s seconds', time() - start_time)
 

--- a/tsstats/config.py
+++ b/tsstats/config.py
@@ -20,7 +20,8 @@ DEFAULT_CONFIG = {
         'onlinedc': True,
         'template': 'index.jinja2',
         'datetimeformat': '%x %X %Z',
-        'onlinetimethreshold': -1
+        'onlinetimethreshold': -1,
+        'lastseenrelative': True
     }
 }
 

--- a/tsstats/log.py
+++ b/tsstats/log.py
@@ -4,13 +4,13 @@ import logging
 import re
 from codecs import open
 from collections import namedtuple
-from datetime import datetime
 from glob import glob
 from os.path import basename
 from time import time
 
+import pendulum
+
 from tsstats.client import Client, Clients
-from tsstats.utils import tz_aware_datime
 
 re_log_filename = re.compile(r'ts3server_(?P<date>\d{4}-\d\d-\d\d)'
                              '__(?P<time>\d\d_\d\d_\d\d.\d+)_(?P<sid>\d).log')
@@ -81,9 +81,9 @@ def _bundle_logs(logs):
         match = re_log_filename.match(basename(log))
         if match:
             match = match.groupdict()
-            timestamp = datetime.strptime('{0} {1}'.format(
-                match['date'], match['time'].replace('_', ':')),
-                log_timestamp_format)
+            timestamp = pendulum.parse('{0} {1}'.format(
+                match['date'], match['time'].replace('_', ':'))
+            )
             tl = TimedLog(log, timestamp)
             sid = match['sid']
             if sid in vserver_logfiles:
@@ -136,8 +136,7 @@ def _parse_details(log_path, ident_map=None, clients=None, online_dc=True):
             logger.debug('No match: "%s"', line)
             continue
         match = match.groupdict()
-        logdatetime = tz_aware_datime(datetime.strptime(match['timestamp'],
-                                      log_timestamp_format))
+        logdatetime = pendulum.parse(match['timestamp'])
         message = match['message']
         if message.startswith('client'):
             match = re_dis_connect.match(message)
@@ -178,7 +177,7 @@ def _parse_details(log_path, ident_map=None, clients=None, online_dc=True):
             ]
     if online_dc:
         def _reconnect(client):
-            client.disconnect(tz_aware_datime(datetime.utcnow()))
+            client.disconnect(pendulum.now())
             client.connected += 1
         [_reconnect(client) for client in clients if client.connected]
     logger.debug(

--- a/tsstats/log.py
+++ b/tsstats/log.py
@@ -23,8 +23,6 @@ re_disconnect_invoker = re.compile(
     r'invokername=(.*)\ invokeruid=(.*)\ reasonmsg'
 )
 
-log_timestamp_format = '%Y-%m-%d %H:%M:%S.%f'
-
 TimedLog = namedtuple('TimedLog', ['path', 'timestamp'])
 Server = namedtuple('Server', ['sid', 'clients'])
 

--- a/tsstats/template.py
+++ b/tsstats/template.py
@@ -59,7 +59,7 @@ def prepare_clients(clients, onlinetime_threshold=-1):
 
 def render_servers(servers, output, title='TeamspeakStats',
                    template='index.jinja2', datetime_fmt='%x %X %Z',
-                   onlinetime_threshold=-1):
+                   onlinetime_threshold=-1, lastseen_relative=True):
     '''
     Render `servers`
 
@@ -70,6 +70,7 @@ def render_servers(servers, output, title='TeamspeakStats',
     :param template_path: path to template-file
     :param datetime_fmt: custom datetime-format
     :param onlinetime_threshold: threshold for clients onlinetime
+    :param lastseen_relative: render last seen timestamp relative
 
 
     :type servers: [tsstats.log.Server]
@@ -79,6 +80,7 @@ def render_servers(servers, output, title='TeamspeakStats',
     :type template_path: str
     :type datetime_fmt: str
     :type onlinetime_threshold: int
+    :type lastseen_relative: bool
     '''
     # preparse servers
     prepared_servers = [
@@ -98,7 +100,14 @@ def render_servers(servers, output, title='TeamspeakStats',
         formatted = timestamp.strftime(datetime_fmt)
         logger.debug('Formatting timestamp %s -> %s', timestamp, formatted)
         return formatted
+
+    def lastseen(timestamp):
+        if lastseen_relative:
+            return timestamp.diff_for_humans()
+        else:
+            return frmttime(timestamp)
     template_env.filters['frmttime'] = frmttime
+    template_env.filters['lastseen'] = lastseen
     template = template_env.get_template(template)
     logger.debug('Rendering template %s', template)
     template.stream(title=title, servers=prepared_servers,

--- a/tsstats/template.py
+++ b/tsstats/template.py
@@ -2,14 +2,13 @@
 
 import logging
 from collections import namedtuple
-from datetime import datetime
 from os.path import dirname, join
 
+import pendulum
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PackageLoader
 
 from tsstats.log import Server
-from tsstats.utils import (filter_threshold, seconds_to_text, sort_clients,
-                           tz_aware_datime)
+from tsstats.utils import filter_threshold, seconds_to_text, sort_clients
 
 logger = logging.getLogger('tsstats')
 
@@ -43,8 +42,7 @@ def prepare_clients(clients, onlinetime_threshold=-1):
         clients, lambda c: c.onlinetime.total_seconds()
     )
     # filter clients not matching threshold
-    onlinetime_ = filter_threshold(onlinetime_,
-                                   onlinetime_threshold)
+    onlinetime_ = filter_threshold(onlinetime_, onlinetime_threshold)
     # convert timespans to text
     onlinetime = [
         (client, seconds_to_text(int(onlinetime)))
@@ -105,6 +103,6 @@ def render_servers(servers, output, title='TeamspeakStats',
     logger.debug('Rendering template %s', template)
     template.stream(title=title, servers=prepared_servers,
                     debug=logger.level <= logging.DEBUG,
-                    creation_time=tz_aware_datime(datetime.utcnow()))\
+                    creation_time=pendulum.utcnow())\
         .dump(output, encoding='utf-8')
     logger.debug('Wrote rendered template to %s', output)

--- a/tsstats/templates/stats.jinja2
+++ b/tsstats/templates/stats.jinja2
@@ -14,7 +14,7 @@
     {% set id = [headline_id, client.nick|striptags]|join('.') %}
     <li id="{{ id }}" class="list-group-item{{ ' list-group-item-success' if client.connected else loop.cycle('" style="background-color: #eee;', '') }}">
       <span class="hint--right hint--medium--xs" data-hint="{{ client.nick_history|join(', ') }}"><a href="#{{ id }}">{{ client.nick }}{{ " (" + client.identifier + ")" if debug }}</a></span>
-      <span class="badge"><div{% if not client.connected and headline == 'Onlinetime' %} class="hint--left" data-hint="{{ client.last_seen.diff_for_humans() }}"{% endif %}>{{ value }}</div></span>
+      <span class="badge"><div{% if not client.connected and headline == 'Onlinetime' %} class="hint--left" data-hint="{{ client.last_seen|lastseen }}"{% endif %}>{{ value }}</div></span>
     </li>
     {% endfor %}
   </ul>

--- a/tsstats/templates/stats.jinja2
+++ b/tsstats/templates/stats.jinja2
@@ -14,7 +14,7 @@
     {% set id = [headline_id, client.nick|striptags]|join('.') %}
     <li id="{{ id }}" class="list-group-item{{ ' list-group-item-success' if client.connected else loop.cycle('" style="background-color: #eee;', '') }}">
       <span class="hint--right hint--medium--xs" data-hint="{{ client.nick_history|join(', ') }}"><a href="#{{ id }}">{{ client.nick }}{{ " (" + client.identifier + ")" if debug }}</a></span>
-      <span class="badge"><div{% if not client.connected and headline == 'Onlinetime' %} class="hint--left" data-hint="{{ client.last_seen|frmttime }}"{% endif %}>{{ value }}</div></span>
+      <span class="badge"><div{% if not client.connected and headline == 'Onlinetime' %} class="hint--left" data-hint="{{ client.last_seen.diff_for_humans() }}"{% endif %}>{{ value }}</div></span>
     </li>
     {% endfor %}
   </ul>

--- a/tsstats/tests/test_log.py
+++ b/tsstats/tests/test_log.py
@@ -1,5 +1,3 @@
-from datetime import datetime, timedelta
-
 import pendulum
 import pytest
 
@@ -20,8 +18,10 @@ def test_log_client_count(clients):
 
 
 def test_log_onlinetime(clients):
-    assert clients['1'].onlinetime == timedelta(0, 402, 149208)
-    assert clients['2'].onlinetime == timedelta(0, 19, 759644)
+    assert clients['1'].onlinetime == pendulum.Interval(
+        seconds=402, microseconds=149208)
+    assert clients['2'].onlinetime == pendulum.Interval(
+        seconds=19, microseconds=759644)
 
 
 def test_log_kicks(clients):
@@ -52,12 +52,20 @@ def test_log_pbans(clients):
         ],
         {
             '1': [
-                TimedLog('ts3server_2016-06-06__14_22_09.527229_1.log',
-                         datetime(year=2016, month=6, day=6, hour=14,
-                                  minute=22, second=9, microsecond=527229)),
-                TimedLog('ts3server_2017-07-07__15_23_10.638340_1.log',
-                         datetime(year=2017, month=7, day=7, hour=15,
-                                  minute=23, second=10, microsecond=638340))
+                TimedLog(
+                    'ts3server_2016-06-06__14_22_09.527229_1.log',
+                    pendulum.create(
+                        year=2016, month=6, day=6, hour=14, minute=22,
+                        second=9, microsecond=527229
+                    )
+                ),
+                TimedLog(
+                    'ts3server_2017-07-07__15_23_10.638340_1.log',
+                    pendulum.create(
+                        year=2017, month=7, day=7, hour=15, minute=23,
+                        second=10, microsecond=638340
+                    )
+                )
             ]
         }
     )

--- a/tsstats/tests/test_log.py
+++ b/tsstats/tests/test_log.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
-from time import sleep
 
+import pendulum
 import pytest
 
 from tsstats.exceptions import InvalidLog
@@ -71,11 +71,14 @@ def test_log_invalid():
         _parse_details('tsstats/tests/res/test.log.broken')
 
 
-@pytest.mark.slowtest
 def test_log_client_online():
+    current_time = pendulum.now()
+
+    pendulum.set_test_now(current_time)
     clients = _parse_details(testlog_path)
     old_onlinetime = int(clients['1'].onlinetime.total_seconds())
-    sleep(2)
+
+    pendulum.set_test_now(current_time.add(seconds=2))  # add 2s to .now()
     clients = _parse_details(testlog_path)
     assert int(clients['1'].onlinetime.total_seconds()) == old_onlinetime + 2
 

--- a/tsstats/tests/test_template.py
+++ b/tsstats/tests/test_template.py
@@ -2,8 +2,8 @@ import logging
 
 import pendulum
 import pytest
-
 from bs4 import BeautifulSoup
+
 from tsstats.log import Server, _parse_details
 from tsstats.template import render_servers
 from tsstats.utils import filter_threshold, seconds_to_text, sort_clients

--- a/tsstats/tests/test_template.py
+++ b/tsstats/tests/test_template.py
@@ -1,9 +1,9 @@
 import logging
-from datetime import timedelta
 
+import pendulum
 import pytest
-from bs4 import BeautifulSoup
 
+from bs4 import BeautifulSoup
 from tsstats.log import Server, _parse_details
 from tsstats.template import render_servers
 from tsstats.utils import filter_threshold, seconds_to_text, sort_clients
@@ -44,7 +44,7 @@ def test_onlinetime(soup):
         onlinetime = onlinetime.text
         # find corresponding client-object
         client = list(filter(
-            lambda c: c.nick == nick and c.onlinetime > timedelta(0),
+            lambda c: c.nick == nick and c.onlinetime > pendulum.Interval(),
             clients
         ))
         # assert existence

--- a/tsstats/utils.py
+++ b/tsstats/utils.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-import datetime
-
-
 def sort_clients(clients, key_l):
     '''
     sort `clients` by `key`
@@ -50,34 +47,6 @@ def filter_threshold(clients, threshold):
     :rtype: list
     '''
     return list(filter(lambda c: c[1] > threshold, clients))
-
-
-class UTC(datetime.tzinfo):
-    '''
-    Reimplementation of `timezone.utc` for Python2-Compatibility
-    '''
-
-    def utcoffset(self, dt):
-        return datetime.timedelta(0)
-
-    def dst(self, dt):
-        return datetime.timedelta(0)
-
-    def tzname(self, dt):
-        return 'UTC'
-
-
-def tz_aware_datime(datetime, timezone=UTC()):
-    '''
-    Make `datetime` aware of it's timezone (UTC by default)
-
-    :param datetime: Target datetime
-    :param timezone: Target timezone
-
-    :type datetime: datetime.datetime
-    :type timezone: datetime.timezone
-    '''
-    return datetime.replace(tzinfo=timezone)
 
 
 def transform_pretty_identmap(pretty_identmap):


### PR DESCRIPTION
[Pendulum](https://pendulum.eustace.io/) provides a more convenient replacement for `datetime`.
Using it would eliminate the `tz_aware_timestamp`-hack and implementing the UTC-timezone for Python 2 compatibility.

**Drawback**: `~0,5` seconds slower than the old implementation (at least for big log collections).